### PR TITLE
Remove too strict read-conflict check in favor of adding request aware readCurrent

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -93,7 +93,7 @@ eggs =
     gocept.pytestlayer
     pytest
     pytest-cov
-    plone.server[test]
+    plone.server [test]
     plone.example
 
 [versions]

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,8 @@ setup(
     extras_require={
         'test': [
             'pytest',
-            'requests'
+            'requests',
+            'zope.testing'
         ]
     },
     entry_points={

--- a/src/plone.server/plone/server/api/dexterity.py
+++ b/src/plone.server/plone/server/api/dexterity.py
@@ -26,7 +26,7 @@ from zope.securitypolicy.interfaces import IPrincipalPermissionMap
 from zope.securitypolicy.interfaces import IPrincipalRoleManager
 from zope.securitypolicy.interfaces import IPrincipalRoleMap
 from zope.securitypolicy.interfaces import IRolePermissionMap
-
+import uuid
 import logging
 
 
@@ -57,7 +57,8 @@ class DefaultPOST(Service):
 
         # Generate a temporary id if the id is not given
         if not id_ and title:
-            new_id = INameChooser(self.context).chooseName(title, object())
+            # new_id = INameChooser(self.context).chooseName(title, object())
+            new_id = uuid.uuid4().hex
         elif not id_:
             now = datetime.now()
             new_id = '{}.{}.{}{:04d}'.format(
@@ -67,12 +68,6 @@ class DefaultPOST(Service):
                 randint(0, 9999))
         else:
             new_id = id_
-
-        # It already exists
-        if new_id in self.context:
-            return ErrorResponse(
-                'Conflict',
-                _("Id already exists"))
 
         user = get_authenticated_user_id(self.request)
         # Create object

--- a/src/plone.server/plone/server/content.py
+++ b/src/plone.server/plone/server/content.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 from plone.dexterity.content import Container
+from plone.dexterity.content import BTreeContainer
 from plone.registry import Registry
 from plone.registry.interfaces import IRegistry
 from plone.server.browser import get_physical_path
 from plone.server.interfaces import IItem
+from plone.server.interfaces import IFolder
 from plone.server.interfaces import IPloneSite
 from plone.server.interfaces import IStaticDirectory
 from plone.server.interfaces import IStaticFile
@@ -71,6 +73,17 @@ class PloneSite(Container):
 
 @implementer(IItem)
 class Item(Container):
+
+    def __repr__(self):
+        path = '/'.join(get_physical_path(self))
+        return "< {type} at {path} by {mem} >".format(
+            type=self.portal_type,
+            path=path,
+            mem=id(self))
+
+
+@implementer(IFolder)
+class Folder(BTreeContainer):
 
     def __repr__(self):
         path = '/'.join(get_physical_path(self))

--- a/src/plone.server/plone/server/content.zcml
+++ b/src/plone.server/plone/server/content.zcml
@@ -18,6 +18,12 @@
       behaviors=".behaviors.dublincore.IDublinCore"
     />
 
+  <plone:contenttype
+      portal_type="Folder"
+      schema=".content.IFolder"
+      class=".content.Folder"
+    />
+
    <adapter
    	  for="plone.server.interfaces.IDataBase
    	       plone.server.interfaces.IRequest"

--- a/src/plone.server/plone/server/factory.py
+++ b/src/plone.server/plone/server/factory.py
@@ -229,6 +229,10 @@ class DataBase(object):
         self._conn = None
         self.tm_ = RequestAwareTransactionManager()
 
+    def open(self):
+        tm_ = RequestAwareTransactionManager()
+        return self._db.open(transaction_manager=self.tm_)
+
     def _open(self):
         self._conn = self._db.open(transaction_manager=self.tm_)
 
@@ -324,7 +328,7 @@ def make_app(config_file=None, settings=None):
             config = dbconfig.get('configuration', {})
             if dbconfig['storage'] == 'ZODB':
                 # Open it not Request Aware so it creates the root object
-                fs = ZODB.FileStorage.FileStorage(dbconfig['path'], **config)
+                fs = ZODB.FileStorage.FileStorage(dbconfig['path'])
 
                 db = DB(fs)
                 db.close()
@@ -335,13 +339,13 @@ def make_app(config_file=None, settings=None):
                 # Try to open it normal to create the root object
                 address = (dbconfig['address'], dbconfig['port'])
 
-                cs = ClientStorage(address, **config)
+                cs = ClientStorage(address)
                 db = DB(cs)
                 db.close()
 
                 # Set request aware database for app
-                cs = ClientStorage(address, **config)
-                db = RequestAwareDB(cs)
+                cs = ClientStorage(address)
+                db = RequestAwareDB(cs, **config)
                 dbo = DataBase(key, db)
             elif dbconfig['storage'] == 'DEMO':
                 storage = DemoStorage(name=dbconfig['name'])

--- a/src/plone.server/plone/server/interfaces.py
+++ b/src/plone.server/plone/server/interfaces.py
@@ -44,6 +44,10 @@ class IItem(model.Schema):
     pass
 
 
+class IFolder(model.Schema):
+    pass
+
+
 class IContentNegotiation(Interface):
     pass
 

--- a/src/plone.server/plone/server/transactions.py
+++ b/src/plone.server/plone/server/transactions.py
@@ -352,9 +352,14 @@ def get_current_request():
     """
     frame = inspect.currentframe()
     while frame is not None:
-        if IView.providedBy(frame.f_locals.get('self')):
-            return frame.f_locals.get('self').request
+        request = getattr(frame.f_locals.get('self'), 'request', None)
+        if request is not None:
+            return request
         elif isinstance(frame.f_locals.get('self'), RequestHandler):
             return frame.f_locals['request']
+        # if isinstance(frame.f_locals.get('self'), RequestHandler):
+        #     return frame.f_locals.get('self').request
+        # elif IView.providedBy(frame.f_locals.get('self')):
+        #     return frame.f_locals['request']
         frame = frame.f_back
     raise RequestNotFound(RequestNotFound.__doc__)

--- a/src/plone.server/plone/server/transactions.py
+++ b/src/plone.server/plone/server/transactions.py
@@ -10,7 +10,6 @@ from plone.server.interfaces import IView
 from transaction._manager import _new_transaction
 from transaction.interfaces import ISavepoint
 from transaction.interfaces import ISavepointDataManager
-from ZODB.POSException import ConflictError
 from zope.interface import implementer
 from zope.proxy import ProxyBase
 
@@ -157,11 +156,6 @@ class RequestDataManager(object):
             pass
 
     def tpc_vote(self, txn):
-        # Check that objects have been updated during commit
-        for ob in self._registered_objects:
-            if ob._p_mtime and ob._p_mtime > self.request._txn_time:
-                raise ConflictError()  # vote 'no'
-
         self.connection.tpc_vote(txn)
 
     def tpc_finish(self, txn):
@@ -190,6 +184,26 @@ class RequestAwareConnection(ZODB.Connection.Connection):
     executor = ThreadPoolExecutor(max_workers=1)
     lock = threading.Lock()
 
+    def _getReadCurrent(self):
+        try:
+            request = get_current_request()
+        except RequestNotFound:
+            return dict()
+        try:
+            return request._txn_readCurrent
+        except AttributeError:
+            request._txn_readCurrent = {}
+            return request._txn_readCurrent
+
+    def _setReadCurrent(self, value):
+        try:
+            request = get_current_request()
+        except RequestNotFound:
+            return
+        request._txn_readCurrent = value
+
+    _readCurrent = property(_getReadCurrent, _setReadCurrent)
+
     def _register(self, obj=None):
         request = get_current_request()
 
@@ -208,13 +222,15 @@ class RequestAwareDB(ZODB.DB):
 
 
 class TransactionProxy(ProxyBase):
-    __slots__ = ('_wrapped', '_txn', '_txn_time', '_txn_dm')
+    __slots__ = ('_wrapped',
+                 '_txn', '_txn_time', '_txn_dm', '_txn_readCurrent')
 
     def __init__(self, obj):
         super(TransactionProxy, self).__init__(obj)
         self._txn = None
         self._txn_time = None
         self._txn_dm = None
+        self._txn_readCurrent = {}
 
 
 @implementer(ISavepoint)

--- a/src/plone.server/setup.py
+++ b/src/plone.server/setup.py
@@ -54,7 +54,8 @@ setup(
     extras_require={
         'test': [
             'pytest',
-            'requests'
+            'requests',
+            'zope.testing',
         ]
     },
     entry_points={


### PR DESCRIPTION
@bloodbare 

I managed to reproduce your conflict error in tests, then I removed the unnecessary check raising it, added proper "request aware" support for readCurrent and tested that it properly raises ReadConflictErrors with multiple connections.

Yet, old rules still apply. When writing a lot into a single BTree you should lock BTree for each concurrent request and only achieve real write concurrency with multiple processes instead. As long as there's only a single bucket in BTree, each addition will also mark the main BTree dirty. Then it should start balancing, but still you cannot know, if two concurrent requests would end up writing into the same bucket. Without locking, those would register write for wrong transaction. With multiple processes, those would properly raise conficts.

