### PR TITLE
actually save data

### DIFF
--- a/src/plone.server/CHANGELOG.rst
+++ b/src/plone.server/CHANGELOG.rst
@@ -1,7 +1,8 @@
 1.0a6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix issue where you could not save data with the API
+  [vangheem]
 
 
 1.0a5 (2016-11-21)

--- a/src/plone.server/plone/server/content.py
+++ b/src/plone.server/plone/server/content.py
@@ -223,6 +223,7 @@ class Resource(Persistent):
     uuid = None
     creation_date = None
     modification_date = None
+    title = None
 
     def __init__(self, id=None):
         if id is not None:

--- a/src/plone.server/plone/server/interfaces.py
+++ b/src/plone.server/plone/server/interfaces.py
@@ -72,6 +72,13 @@ class IRegistry(IFullMapping):
 class IResource(IContained):
     portal_type = schema.TextLine()
 
+    title = schema.TextLine(
+        title='Title',
+        required=False,
+        description=u"Title of the Site",
+        default=u''
+    )
+
 
 class IResourceFactory(IFactory):
 
@@ -102,12 +109,7 @@ class IResourceFactory(IFactory):
 
 
 class ISite(IResource, IZopeSite):
-    title = schema.TextLine(
-        title='Title',
-        required=False,
-        description=u"Title of the Site",
-        default=u''
-    )
+    pass
 
 
 class IItem(IResource):

--- a/src/plone.server/plone/server/json/deserialize_content.py
+++ b/src/plone.server/plone/server/json/deserialize_content.py
@@ -98,7 +98,7 @@ class DeserializeFromJson(object):
                         errors.append({
                             'message': e.doc(), 'field': name, 'error': e})
                     else:
-                        setattr(schema, name, value)
+                        setattr(obj, name, value)
         if validate_all:
             validation = getValidationErrors(schema, schema(self.context))
 

--- a/src/plone.server/plone/server/tests/test_api.py
+++ b/src/plone.server/plone/server/tests/test_api.py
@@ -89,6 +89,9 @@ class FunctionalTestServer(PloneFunctionalTestCase):
             })
         )
         self.assertTrue(resp.status_code == 201)
+        root = self.layer.new_root()
+        obj = root['plone']['item1']
+        self.assertEqual(obj.title, 'Item1')
 
     def test_create_delete_contenttype(self):
         """Create and delete a content type."""


### PR DESCRIPTION
@bloodbare Is this right?

Without this, from what I see, no data gets saved when you create content with the api.

Requirement to save data with API:

1. interface for content defines property in the schema
2. content type has a default value for it

Or

Behavior, which is an adapter on the object, manually saves the data.