### PR TITLE
Rethink how authentication is done

### DIFF
--- a/config-zeo.json
+++ b/config-zeo.json
@@ -17,7 +17,7 @@
 	],
 	"creator": {
 		"admin": "admin",
-		"password": "YWRtaW4="
+		"password": "admin"
 	},
 	"cors": {
 		"allow_origin": ["*"],

--- a/config-zodb.json
+++ b/config-zodb.json
@@ -16,7 +16,7 @@
 	],
 	"creator": {
 		"admin": "admin",
-		"password": "YWRtaW4="
+		"password": "admin"
 	},
 	"cors": {
 		"allow_origin": ["*"],

--- a/config.json
+++ b/config.json
@@ -15,9 +15,8 @@
 	"static": [
 		{"favicon.ico": "static/favicon.ico"}
 	],
-	"creator": {
-		"admin": "admin",
-		"password": "YWRtaW4="
+	"root_user": {
+		"password": "admin"
 	},
 	"cors": {
 		"allow_origin": ["*"],

--- a/src/plone.server/CHANGELOG.rst
+++ b/src/plone.server/CHANGELOG.rst
@@ -1,6 +1,10 @@
 1.0a7 (unreleased)
 ------------------
 
+- Remove `AUTH_USER_PLUGINS` and `AUTH_EXTRACTION_PLUGINS`. Authentication now
+  consists of auth policies, user identifiers and token checkers.
+  [vangheem]
+
 - Correctly check parent object for allowed addable types
   [vangheem]
 

--- a/src/plone.server/README.rst
+++ b/src/plone.server/README.rst
@@ -38,7 +38,7 @@ Creating default content
 
 Once started, you will require to add at least a Plone site to start fiddling around::
 
-  curl -X POST -H "Accept: application/json" -H "Authorization: Basic YWRtaW4=" -H "Content-Type: application/json" -d '{
+  curl -X POST -H "Accept: application/json" -H "Authorization: Basic admin" -H "Content-Type: application/json" -d '{
     "@type": "Site",
     "title": "Plone 1",
     "id": "plone",
@@ -47,7 +47,7 @@ Once started, you will require to add at least a Plone site to start fiddling ar
 
 and give permissions to add content to it::
 
-  curl -X POST -H "Accept: application/json" -H "Authorization: Basic YWRtaW4=" -H "Content-Type: application/json" -d '{
+  curl -X POST -H "Accept: application/json" -H "Authorization: Basic admin" -H "Content-Type: application/json" -d '{
     "prinrole": {
         "Anonymous User": ["plone.Member", "plone.Reader"]
     }
@@ -55,7 +55,7 @@ and give permissions to add content to it::
 
 and create actual content::
 
-  curl -X POST -H "Accept: application/json" -H "Authorization: Basic YWRtaW4=" -H "Content-Type: application/json" -d '{
+  curl -X POST -H "Accept: application/json" -H "Authorization: Basic admin" -H "Content-Type: application/json" -d '{
     "@type": "Item",
     "title": "News",
     "id": "news"
@@ -76,7 +76,7 @@ and for test coverage::
 Default
 -------
 
-Default root access can be done with AUTHORIZATION header : Basic YWRtaW4=
+Default root access can be done with AUTHORIZATION header : Basic admin
 
 
 Running dependency graph

--- a/src/plone.server/plone/server/__init__.py
+++ b/src/plone.server/plone/server/__init__.py
@@ -5,16 +5,34 @@ import collections
 
 _ = MessageFactory('plone')
 
-DICT_METHODS = {}
-DICT_RENDERS = collections.OrderedDict()
-DICT_LANGUAGES = {}
-DEFAULT_LAYER = []
-DEFAULT_PERMISSION = []
-AVAILABLE_ADDONS = {}
-JSON_API_DEFINITION = {}
-AUTH_EXTRACTION_PLUGINS = []
-AUTH_USER_PLUGINS = []
-CORS = {}
+app_settings = {
+    'databases': [],
+    'address': 8080,
+    'static': [],
+    'utilities': [],
+    'root_user': {
+        'id': 'admin',
+        'password': ''
+    },
+    'auth_policies': [
+        'plone.server.auth.policies.BearerAuthPolicy',
+        'plone.server.auth.policies.WSTokenAuthPolicy',
+    ],
+    'auth_user_identifiers': [
+        'plone.server.auth.users.RootUserIdentifier'
+    ],
+    'auth_token_checker': [
+        'plone.server.auth.checkers.SaltedHashPasswordChecker',
+    ],
+    'default_layers': [],
+    'http_methods': {},
+    'renderers': collections.OrderedDict(),
+    'languages': {},
+    'default_permission': '',
+    'available_addons': {},
+    'api_definition': {},
+    'cors': {}
+}
 
 SCHEMA_CACHE = {}
 PERMISSIONS_CACHE = {}

--- a/src/plone.server/plone/server/api/addons.py
+++ b/src/plone.server/plone/server/api/addons.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from plone.server import _
-from plone.server import AVAILABLE_ADDONS
+from plone.server import app_settings
 from plone.server.api.service import Service
 from plone.server.browser import ErrorResponse
 from plone.server.registry import IAddons
@@ -10,7 +10,7 @@ class Install(Service):
     async def __call__(self):
         data = await self.request.json()
         id_to_install = data.get('id', None)
-        if id_to_install not in AVAILABLE_ADDONS:
+        if id_to_install not in app_settings['available_addons']:
             return ErrorResponse(
                 'RequiredParam',
                 _("Property 'id' is required to be valid"))
@@ -22,7 +22,7 @@ class Install(Service):
             return ErrorResponse(
                 'Duplicate',
                 _("Addon already installed"))
-        handler = AVAILABLE_ADDONS[id_to_install]['handler']
+        handler = app_settings['available_addons'][id_to_install]['handler']
         handler.install(self.request)
         config.enabled |= {id_to_install}
 
@@ -31,7 +31,7 @@ class Uninstall(Service):
     async def __call__(self):
         data = await self.request.json()
         id_to_install = data.get('id', None)
-        if id_to_install not in AVAILABLE_ADDONS:
+        if id_to_install not in app_settings['available_addons']:
             return ErrorResponse(
                 'RequiredParam',
                 _("Property 'id' is required to be valid"))
@@ -44,7 +44,7 @@ class Uninstall(Service):
                 'Duplicate',
                 _("Addon not installed"))
 
-        handler = AVAILABLE_ADDONS[id_to_install]['handler']
+        handler = app_settings['available_addons'][id_to_install]['handler']
         handler.uninstall(self.request)
         config.enabled -= {id_to_install}
 
@@ -55,7 +55,7 @@ class getAddons(Service):
             'available': [],
             'installed': []
         }
-        for key, addon in AVAILABLE_ADDONS.items():
+        for key, addon in app_settings['available_addons'].items():
             result['available'].append({
                 'id': key,
                 'title': addon['title']

--- a/src/plone.server/plone/server/api/app.py
+++ b/src/plone.server/plone/server/api/app.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from plone.server import JSON_API_DEFINITION
+from plone.server import app_settings
 from plone.server.api.service import Service
 from plone.server.json.interfaces import IResourceSerializeToJson
 from zope.component import getMultiAdapter
@@ -20,4 +20,4 @@ class DefaultGET(Service):
 
 class GetAPIDefinition(Service):
     async def __call__(self):
-        return JSON_API_DEFINITION
+        return app_settings['api_definition']

--- a/src/plone.server/plone/server/api/content.py
+++ b/src/plone.server/plone/server/api/content.py
@@ -13,7 +13,7 @@ from plone.server.interfaces import IAbsoluteURL
 from plone.server.json.exceptions import DeserializationError
 from plone.server.json.interfaces import IResourceDeserializeFromJson
 from plone.server.json.interfaces import IResourceSerializeToJson
-from plone.server import CORS
+from plone.server import app_settings
 from plone.server.utils import get_authenticated_user_id
 from plone.server.utils import iter_parents
 from random import randint
@@ -201,7 +201,7 @@ class DefaultOPTIONS(Service):
         """We need to check if there is cors enabled and is valid."""
         headers = {}
 
-        if not CORS:
+        if not app_settings['cors']:
             return {}
 
         origin = self.request.headers.get('Origin', None)
@@ -220,13 +220,13 @@ class DefaultOPTIONS(Service):
             requested_headers = map(str.strip, requested_headers.split(', '))
 
         requested_method = requested_method.upper()
-        allowed_methods = CORS['allow_methods']
+        allowed_methods = app_settings['cors']['allow_methods']
         if requested_method not in allowed_methods:
             raise HTTPMethodNotAllowed(
                 requested_method, allowed_methods,
                 text='Access-Control-Request-Method Method not allowed')
 
-        supported_headers = CORS['allow_headers']
+        supported_headers = app_settings['cors']['allow_headers']
         if '*' not in supported_headers and requested_headers:
             supported_headers = [s.lower() for s in supported_headers]
             for h in requested_headers:
@@ -242,8 +242,8 @@ class DefaultOPTIONS(Service):
         headers['Access-Control-Allow-Headers'] = ','.join(
             supported_headers)
         headers['Access-Control-Allow-Methods'] = ','.join(
-            CORS['allow_methods'])
-        headers['Access-Control-Max-Age'] = str(CORS['max_age'])
+            app_settings['cors']['allow_methods'])
+        headers['Access-Control-Max-Age'] = str(app_settings['cors']['max_age'])
         return headers
 
     async def render(self):

--- a/src/plone.server/plone/server/auth/__init__.py
+++ b/src/plone.server/plone/server/auth/__init__.py
@@ -1,0 +1,29 @@
+from plone.server import app_settings
+from plone.server.utils import resolve_or_get
+
+
+async def authenticate_request(request):
+    for policy in app_settings['auth_policies']:
+        policy = resolve_or_get(policy)
+        token = await policy(request).extract_token()
+        if token:
+            user = await find_user(request, token)
+            if user:
+                if await authenticate_user(request, user, token):
+                    return user
+
+
+async def find_user(request, token):
+    for identifier in app_settings['auth_user_identifiers']:
+        identifier = resolve_or_get(identifier)
+        user = await identifier(request).get_user()
+        if user:
+            return user
+
+
+async def authenticate_user(request, user, token):
+    for checker in app_settings['auth_token_checker']:
+        checker = resolve_or_get(checker)
+        if await checker(request).validate(user, token):
+            return True
+    return False

--- a/src/plone.server/plone/server/auth/checkers.py
+++ b/src/plone.server/plone/server/auth/checkers.py
@@ -1,0 +1,33 @@
+from plone.server.utils import strings_differ
+
+import hashlib
+import uuid
+
+
+def hash_password(password, salt=None):
+    if salt is None:
+        salt = uuid.uuid4().hex
+
+    if isinstance(salt, str):
+        salt = salt.encode('utf-8')
+
+    if isinstance(password, str):
+        password = password.encode('utf-8')
+
+    hashed_password = hashlib.sha512(password + salt).hexdigest()
+    return '{}:{}'.format(salt.decode('utf-8'), hashed_password)
+
+
+class SaltedHashPasswordChecker(object):
+
+    def __init__(self, request):
+        self.request = request
+
+    async def validate(self, user, token):
+        user_pw = getattr(user, 'password', None)
+        if (not user_pw or
+                ':' not in user_pw or
+                'password' not in token):
+            return False
+        salt = user.password.split(':')[0]
+        return not strings_differ(hash_password(token['password'], salt), user_pw)

--- a/src/plone.server/plone/server/auth/policies.py
+++ b/src/plone.server/plone/server/auth/policies.py
@@ -1,0 +1,57 @@
+from plone.server import app_settings
+from plone.server import jose
+
+
+class BasePolicy(object):
+
+    def __init__(self, request):
+        self.request = request
+
+    async def extract_token(self):
+        """
+        Extracts token from request.
+        This will be a dictionary including something like {id, password},
+        depending on the auth policy to authenticate user against
+        """
+        raise NotImplemented()
+
+
+class BearerAuthPolicy(BasePolicy):
+    async def extract_token(self):
+        header_auth = self.request.headers.get('AUTHORIZATION')
+        if header_auth is not None:
+            schema, _, encoded_token = header_auth.partition(' ')
+            if schema.lower() == 'basic' or schema.lower() == 'bearer':
+                return {
+                    'password': encoded_token
+                }
+
+
+class WSTokenAuthPolicy(BasePolicy):
+    async def extract_token(self):
+        request = self.request
+        if 'ws_token' in request.GET:
+            jwt_token = request.GET['ws_token'].encode('utf-8')
+            request.GET['ws_token'].encode('utf-8')
+            jwt = jose.decrypt(
+                jose.deserialize_compact(jwt_token), app_settings['rsa']['priv'])
+            return {
+                'password': jwt.claims['token']
+            }
+
+
+class BasicAuthPolicy(BasePolicy):
+    async def extract_token(self):
+        header_auth = self.request.headers.get('AUTHORIZATION')
+        if header_auth is not None:
+            schema, _, encoded_token = header_auth.partition(' ')
+            if schema.lower() == 'basic' or schema.lower() == 'bearer':
+                userid, _, password = encoded_token.partition(':')
+                return {
+                    'id': userid,
+                    'password': password
+                }
+
+
+class JWTAuthPolicy(BasePolicy):
+    pass

--- a/src/plone.server/plone/server/auth/users.py
+++ b/src/plone.server/plone/server/auth/users.py
@@ -1,0 +1,8 @@
+
+
+class RootUserIdentifier(object):
+    def __init__(self, request):
+        self.request = request
+
+    async def get_user(self):
+        return self.request.application.root_user

--- a/src/plone.server/plone/server/behaviors/dublincore.py
+++ b/src/plone.server/plone/server/behaviors/dublincore.py
@@ -2,7 +2,7 @@
 from datetime import datetime
 from dateutil.tz import tzlocal
 from dateutil.tz import tzutc
-from plone.server import DICT_LANGUAGES
+from plone.server import app_settings
 from plone.server.behaviors.properties import ContextProperty
 from plone.server.directives import catalog
 from plone.server.directives import index
@@ -22,7 +22,7 @@ OPTIONS = [
     SimpleTerm(value=_languagelist[l]['native'],
                token=l,
                title=_languagelist[l]['name'])
-    for l in DICT_LANGUAGES.keys() if l in _languagelist
+    for l in app_settings['languages'].keys() if l in _languagelist
 ]
 language_vocabulary = SimpleVocabulary(OPTIONS)
 _zone = tzlocal()

--- a/src/plone.server/plone/server/content.py
+++ b/src/plone.server/plone/server/content.py
@@ -1,12 +1,16 @@
 # -*- coding: utf-8 -*-
-import uuid
-from datetime import datetime
-from dateutil.tz import tzlocal
 from BTrees.Length import Length
 from BTrees.OOBTree import OOBTree
+from datetime import datetime
+from dateutil.tz import tzlocal
 from persistent import Persistent
-from plone.behavior.markers import applyMarkers
+from plone.behavior.interfaces import IBehavior
 from plone.behavior.interfaces import IBehaviorAssignable
+from plone.behavior.markers import applyMarkers
+from plone.server import FACTORY_CACHE
+from plone.server import PERMISSIONS_CACHE
+from plone.server import SCHEMA_CACHE
+from plone.server.auth.participation import ROOT_USER_ID
 from plone.server.browser import get_physical_path
 from plone.server.interfaces import DEFAULT_ADD_PERMISSION
 from plone.server.interfaces import IContainer
@@ -17,31 +21,29 @@ from plone.server.interfaces import IResourceFactory
 from plone.server.interfaces import ISite
 from plone.server.interfaces import IStaticDirectory
 from plone.server.interfaces import IStaticFile
-from plone.server import SCHEMA_CACHE
-from plone.server import PERMISSIONS_CACHE
-from plone.server import FACTORY_CACHE
-from plone.behavior.interfaces import IBehavior
 from plone.server.registry import IAddons
 from plone.server.registry import ILayers
 from plone.server.registry import Registry
-from plone.server.utils import Lazy
-from plone.server.transactions import synccontext
 from plone.server.transactions import get_current_request
-from plone.server.utils import get_authenticated_user_id
+from plone.server.transactions import synccontext
+from plone.server.utils import Lazy
 from zope.annotation.interfaces import IAttributeAnnotatable
-from zope.component import getUtility
-from zope.component.factory import Factory
-from zope.security.interfaces import IPermission
-from zope.component import queryUtility
 from zope.component import adapter
+from zope.component import getUtility
+from zope.component import queryUtility
+from zope.component.factory import Factory
 from zope.component.persistentregistry import PersistentComponents
 from zope.event import notify
 from zope.interface import implementer
 from zope.interface import Interface
 from zope.lifecycleevent import ObjectAddedEvent
 from zope.lifecycleevent import ObjectRemovedEvent
+from zope.security.interfaces import IPermission
 from zope.securitypolicy.interfaces import IPrincipalRoleManager
 from zope.securitypolicy.principalpermission import PrincipalPermissionManager
+
+import uuid
+
 
 _zone = tzlocal()
 
@@ -335,12 +337,12 @@ class Site(Folder):
         roles = IPrincipalRoleManager(self)
         roles.assignRoleToPrincipal(
             'plone.SiteAdmin',
-            'RootUser'
+            ROOT_USER_ID
         )
 
         roles.assignRoleToPrincipal(
             'plone.Owner',
-            'RootUser'
+            ROOT_USER_ID
         )
 
     def getSiteManager(self):

--- a/src/plone.server/plone/server/contentnegotiation.py
+++ b/src/plone.server/plone/server/contentnegotiation.py
@@ -1,6 +1,5 @@
 # -*- encoding: utf-8 -*-
-from plone.server import DICT_LANGUAGES
-from plone.server import DICT_RENDERS
+from plone.server import app_settings
 from plone.server.interfaces import IContentNegotiation
 from plone.server.interfaces import IDownloadView
 from zope.component import getUtility
@@ -813,13 +812,13 @@ def content_type_negotiation(request, resource, view):
     if IDownloadView.providedBy(view) or accept is None:
         # Its going to be binary
         # No content negotiation right now
-        accept = DICT_RENDERS['*/*']
+        accept = app_settings['renderers']['*/*']
         return accept
 
     np = getUtility(IContentNegotiation, 'content_type')
     ap = np.negotiate(accept=accept)
     # We need to check for the accept
-    accept = DICT_RENDERS[str(ap.content_type)]
+    accept = app_settings['renderers'][str(ap.content_type)]
     return accept
 
 
@@ -835,7 +834,7 @@ def language_negotiation(request):
     ap = np.negotiate(accept_language=accept_lang)
     # We need to check for the accept
     if ap is None:
-        language = DICT_LANGUAGES['en']
+        language = app_settings['languages']['en']
     else:
-        language = DICT_LANGUAGES[str(ap.language)]
+        language = app_settings['languages'][str(ap.language)]
     return language

--- a/tests.json
+++ b/tests.json
@@ -29,7 +29,7 @@
 					},
 					{
 						"key": "Authorization",
-						"value": "Basic YWRtaW4=",
+						"value": "Basic admin",
 						"description": ""
 					}
 				],
@@ -63,7 +63,7 @@
 					},
 					{
 						"key": "Authorization",
-						"value": "Basic YWRtaW4=",
+						"value": "Basic admin",
 						"description": ""
 					}
 				],
@@ -87,7 +87,7 @@
 							},
 							{
 								"key": "Authorization",
-								"value": "Basic YWRtaW4=",
+								"value": "Basic admin",
 								"description": ""
 							}
 						],
@@ -154,7 +154,7 @@
 					},
 					{
 						"key": "Authorization",
-						"value": "Basic YWRtaW4=",
+						"value": "Basic admin",
 						"description": ""
 					}
 				],
@@ -188,7 +188,7 @@
 					},
 					{
 						"key": "Authorization",
-						"value": "Basic YWRtaW4=",
+						"value": "Basic admin",
 						"description": ""
 					},
 					{
@@ -217,7 +217,7 @@
 							},
 							{
 								"key": "Authorization",
-								"value": "Basic YWRtaW4=",
+								"value": "Basic admin",
 								"description": ""
 							},
 							{
@@ -295,7 +295,7 @@
 					},
 					{
 						"key": "Authorization",
-						"value": "Basic YWRtaW4=",
+						"value": "Basic admin",
 						"description": ""
 					},
 					{
@@ -334,7 +334,7 @@
 					},
 					{
 						"key": "Authorization",
-						"value": "Basic YWRtaW4=",
+						"value": "Basic admin",
 						"description": ""
 					}
 				],
@@ -368,7 +368,7 @@
 					},
 					{
 						"key": "Authorization",
-						"value": "Basic YWRtaW4=",
+						"value": "Basic admin",
 						"description": ""
 					}
 				],
@@ -402,7 +402,7 @@
 					},
 					{
 						"key": "Authorization",
-						"value": "Basic YWRtaW4=",
+						"value": "Basic admin",
 						"description": ""
 					}
 				],
@@ -436,7 +436,7 @@
 					},
 					{
 						"key": "Authorization",
-						"value": "Basic YWRtaW4=",
+						"value": "Basic admin",
 						"description": ""
 					},
 					{
@@ -475,7 +475,7 @@
 					},
 					{
 						"key": "Authorization",
-						"value": "Basic YWRtaW4=",
+						"value": "Basic admin",
 						"description": ""
 					}
 				],
@@ -509,7 +509,7 @@
 					},
 					{
 						"key": "Authorization",
-						"value": "Basic YWRtaW4=",
+						"value": "Basic admin",
 						"description": ""
 					}
 				],
@@ -543,7 +543,7 @@
 					},
 					{
 						"key": "Authorization",
-						"value": "Basic YWRtaW4=",
+						"value": "Basic admin",
 						"description": ""
 					},
 					{
@@ -582,7 +582,7 @@
 					},
 					{
 						"key": "Authorization",
-						"value": "Basic YWRtaW4=",
+						"value": "Basic admin",
 						"description": ""
 					},
 					{


### PR DESCRIPTION
I've changed how authentication is architected.

I've removed `AUTH_EXTRACTION_PLUGINS` and `AUTH_USER_PLUGINS` and replaced it with something that I think will be easier for us to extend/use.

The new framework consists of:

- Auth policies: like basic auth/jwt
- User identifiers: by default, only a root user identifier
- Token checkers: by default, we only provide salted hashed implementation


Additional goodies in this PR:
- changed the way we do global variables to use a module level `app_settings` objects. This way, most of our configuration can be setup simply with the `config.json` file instead of needing code to configure it. We can change the details of this implementation but I think we should try and have one configuration object to manage all configuration instead of a bunch of different globals
- I was able to remove the special use-case of root_participation. The implementation is still there--just within the new auth framework
- no more use of base64 encoded password for root user. Root user can be a more complex password but base64 encoding doesn't really provide much at all for us