### PR TITLE
Default value for context

### DIFF
--- a/src/plone.server/CHANGELOG.rst
+++ b/src/plone.server/CHANGELOG.rst
@@ -8,6 +8,9 @@
 - Correctly check parent object for allowed addable types
   [vangheem]
 
+- Get default values from schema when attribute on object is not set
+  [bloodbare]
+
 
 1.0a6 (2016-11-21)
 ------------------


### PR DESCRIPTION
@vangheem @datakurre 

I also don't like the option to have a default get on contenttypes, the problem is on default values on schema. The validation and serialization is not going ok because the content has no values if they are not required.
