### PR TITLE
fix plone newt support

### DIFF
--- a/src/plone.server/plone/server/factory.py
+++ b/src/plone.server/plone/server/factory.py
@@ -485,12 +485,9 @@ def make_app(config_file=None, settings=None):
                 dbo = Database(key, db)
             elif dbconfig['storage'] == 'NEWT' and NEWT:
                 options = Options(**dbconfig['options'])
-                if dbconfig['type'] == 'postgres':
-                    from relstorage.adapters.postgresql import PostgreSQLAdapter
-                    dsn = "dbname={dbname} user={username} host={host} password={password} port={port}".format(**dbconfig['dsn'])
-                    adapter = PostgreSQLAdapter(dsn=dsn, options=options)
-                rs = RelStorage(adapter=adapter, options=options)
-                db = DB(rs)
+                dsn = "dbname={dbname} user={username} host={host} password={password} port={port}".format(**dbconfig['dsn'])
+                adapter = newt.db.storage(dsn=dsn, **dbconfig['options'])
+                db = newt.db.DB(dsn, **dbconfig['options'])
                 try:
                     conn = db.open()
                     rootobj = conn.root()
@@ -503,8 +500,8 @@ def make_app(config_file=None, settings=None):
                     rootobj = None
                     conn.close()
                     db.close()
-                rs = RelStorage(adapter=adapter, options=options)
-                db = newt.db._db.NewtDB(RequestAwareDB(rs, **config))
+                adapter = newt.db.storage(dsn, **dbconfig['options'])
+                db = newt.db._db.NewtDB(RequestAwareDB(adapter, **config))
                 dbo = Database(key, db)
             elif dbconfig['storage'] == 'DEMO':
                 storage = DemoStorage(name=dbconfig['name'])


### PR DESCRIPTION
Current implementation doesn't use newt's storage wrapper.


```
>>> root['newt'].conn.where
<bound method Connection.where of <newt.db._db.Connection object at 0x10a0ec6a0>>
>>> root['newt'].conn.where("""state @> '{"title": "Plone NEWT"}'""")
[< Site at n/a/plonenewt3 by 4463422152 >, < Site at n/a/plonenewt4 by 4463422264 >]
```